### PR TITLE
Feat/재고 관리 도메인 및 Redis 기반 분산 락 구현

### DIFF
--- a/src/main/java/com/example/hotdeal/domain/stock/api/StockController.java
+++ b/src/main/java/com/example/hotdeal/domain/stock/api/StockController.java
@@ -1,4 +1,40 @@
 package com.example.hotdeal.domain.stock.api;
 
+import com.example.hotdeal.domain.stock.application.StockService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/stocks")
+@RequiredArgsConstructor
 public class StockController {
+
+    private final StockService service;
+
+    //재고 차감
+    @PostMapping("/{id}/decrease")
+    public void decrease(@PathVariable Long id,
+                         @RequestParam int quantity) {
+        service.decrease(id, quantity);
+    }
+
+    //재고 증가 (관리자)
+    @PostMapping("/{id}/increase")
+    public void increase(@PathVariable Long id,
+                         @RequestParam int quantity) {
+        service.increase(id, quantity);
+    }
+
+    //재고 리셋 (관리자)
+    @PostMapping("/{id}/reset")
+    public void reset(@PathVariable Long id,
+                      @RequestParam int quantity) {
+        service.reset(id, quantity);
+    }
+
+    // 남은 수량 조회
+    @GetMapping("/{id}/available")
+    public int available(@PathVariable Long id) {
+        return service.available(id);
+    }
 }

--- a/src/main/java/com/example/hotdeal/domain/stock/application/StockService.java
+++ b/src/main/java/com/example/hotdeal/domain/stock/application/StockService.java
@@ -1,4 +1,59 @@
 package com.example.hotdeal.domain.stock.application;
 
+import com.example.hotdeal.domain.stock.domain.Stock;
+import com.example.hotdeal.domain.stock.infra.StockRepository;
+
+import com.example.hotdeal.global.lock.LockService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
 public class StockService {
+
+    private final StockRepository repository;
+    private final LockService lockService;
+    private final StockTransactionService stockTransactionService;
+
+    // 재고 증가 (관리자용)
+    @Transactional
+    public void increase(Long stockId, int qty) {
+        Stock s = repository.findById(stockId).orElseThrow();
+        s.increase(qty);
+    }
+
+    // 재고 초기화 (관리자용)
+    @Transactional
+    public void reset(Long stockId, int qty) {
+        Stock s = repository.findById(stockId).orElseThrow();
+        s.reset(qty);
+    }
+
+    // 남은 수량 조회
+    @Transactional(readOnly = true)
+    public int available(Long stockId) {
+        return repository.findById(stockId)
+                .orElseThrow(() -> new IllegalArgumentException("stock"))
+                .getQuantity();
+    }
+
+    //재고 감소 로직
+    @Transactional
+    public void decrease(Long stockId, int quantity) {
+        Stock stock = repository.findById(stockId).orElseThrow();
+        stock.decrease(quantity);   // dirty checking 후 flush
+    }
+
+  // @Transactional 제거 - Lock 밖에서 트랜잭션이 시작되면 안됨
+   public void decreaseWithLock(Long stockId, int quantity) {
+       String lockKey = String.valueOf(stockId);
+       lockService.executeWithLock(lockKey, () -> {
+           // Lock 내부에서 새로운 트랜잭션 시작
+          stockTransactionService.decreaseInNewTransaction(stockId, quantity);
+          return null;
+       });
+   }
 }

--- a/src/main/java/com/example/hotdeal/domain/stock/application/StockTransactionService.java
+++ b/src/main/java/com/example/hotdeal/domain/stock/application/StockTransactionService.java
@@ -1,0 +1,31 @@
+package com.example.hotdeal.domain.stock.application;
+
+import com.example.hotdeal.domain.stock.domain.Stock;
+import com.example.hotdeal.domain.stock.infra.StockRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+class StockTransactionService {
+
+    private final StockRepository repository;
+
+    @Transactional
+    public void decreaseInNewTransaction(Long stockId, int quantity) {
+        Stock stock = repository.findById(stockId)
+                .orElseThrow(() -> new IllegalArgumentException("재고를 찾을 수 없습니다. ID = " + stockId));
+
+        if (stock.getQuantity() < quantity) {
+            throw new IllegalArgumentException("재고가 부족합니다. 현재 재고: " + stock.getQuantity() + ", Requested: " + quantity);
+        }
+
+        stock.decrease(quantity);
+        log.info("재고 차감 완료. ID: {}, 차감 수량: {}, 남은 재고: {}",
+                stockId, quantity, stock.getQuantity());
+    }
+}
+

--- a/src/main/java/com/example/hotdeal/domain/stock/domain/Stock.java
+++ b/src/main/java/com/example/hotdeal/domain/stock/domain/Stock.java
@@ -1,18 +1,39 @@
 package com.example.hotdeal.domain.stock.domain;
-
 import com.example.hotdeal.global.model.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+
+import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
 @Table(name = "stock")
+@NoArgsConstructor(access = PROTECTED)
 public class Stock extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long stock_id;
+    private Long id;
+    private Long productId;
 
-    private Long product_id;
-    private int stock_count;
+    private int quantity; //실제 재고
+
+
+    public Stock(Long productId, int quantity) {
+        this.productId = productId;
+        this.quantity  = quantity;
+    }
+
+    public Stock(int quantity) {this.quantity = quantity;}
+
+    // 비즈니스 메서드
+    public void decrease(int quantity) {
+        if (this.quantity < quantity) {
+            throw new IllegalStateException("재고 부족");
+        }
+        this.quantity -= quantity;
+    }
+    public void increase(int quantity)        { this.quantity += quantity; }
+    public void reset(int quantity)      { this.quantity = quantity; }
+
 }

--- a/src/main/java/com/example/hotdeal/domain/stock/infra/StockRepository.java
+++ b/src/main/java/com/example/hotdeal/domain/stock/infra/StockRepository.java
@@ -1,4 +1,10 @@
 package com.example.hotdeal.domain.stock.infra;
 
-public interface StockRepository {
+import com.example.hotdeal.domain.stock.domain.Stock;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StockRepository extends JpaRepository<Stock, Long> {
+
 }

--- a/src/main/java/com/example/hotdeal/global/infrastructure/cache/RedisConfig.java
+++ b/src/main/java/com/example/hotdeal/global/infrastructure/cache/RedisConfig.java
@@ -1,4 +1,27 @@
 package com.example.hotdeal.global.infrastructure.cache;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
 public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        // 문자열 직렬화 설정
+        StringRedisSerializer serializer = new StringRedisSerializer();
+        template.setKeySerializer(serializer);
+        template.setValueSerializer(serializer);
+        template.setHashKeySerializer(serializer);
+        template.setHashValueSerializer(serializer);
+
+        template.afterPropertiesSet();
+        return template;
+    }
 }

--- a/src/main/java/com/example/hotdeal/global/lock/LockAcquisitionException.java
+++ b/src/main/java/com/example/hotdeal/global/lock/LockAcquisitionException.java
@@ -1,0 +1,7 @@
+package com.example.hotdeal.global.lock;
+
+public class LockAcquisitionException extends RuntimeException {
+    public LockAcquisitionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/hotdeal/global/lock/LockRedisRepository.java
+++ b/src/main/java/com/example/hotdeal/global/lock/LockRedisRepository.java
@@ -1,0 +1,65 @@
+package com.example.hotdeal.global.lock;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Collections;
+
+@Repository
+@RequiredArgsConstructor
+public class LockRedisRepository {
+
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String LOCK_PREFIX = "stock:lock:";
+
+    /**
+     * 락 획득 시도
+     * @param key 락 키
+     * @param value 락 소유자 식별값
+     * @param duration 락 유지 시간
+     * @return 락 획득 성공 여부
+     */
+    public Boolean tryLock(String key, String value, Duration duration) {
+        String lockKey = generateKey(key);
+        return redisTemplate.opsForValue()
+                .setIfAbsent(lockKey, value, duration);
+    }
+
+
+
+    /**
+     * 락 해제 (Lua 스크립트 사용 - 락 소유자만 해제 가능)
+     * @param key 락 키
+     * @param value 락 소유자 식별값
+     * @return 락 해제 성공 여부
+     */
+    public Boolean unlock(String key, String value) {
+        String lockKey = generateKey(key);
+        String script =
+                "if redis.call('get', KEYS[1]) == ARGV[1] then " +
+                        "  return redis.call('del', KEYS[1]) " +
+                        "else " +
+                        "  return 0 " +
+                        "end";
+
+        Long result = redisTemplate.execute(
+                new DefaultRedisScript<>(script, Long.class),
+                Collections.singletonList(lockKey),
+                value
+        );
+
+        return result != null && result > 0;
+    }
+
+
+
+    private String generateKey(String key) {
+        return LOCK_PREFIX + key;
+    }
+}

--- a/src/main/java/com/example/hotdeal/global/lock/LockService.java
+++ b/src/main/java/com/example/hotdeal/global/lock/LockService.java
@@ -1,0 +1,103 @@
+package com.example.hotdeal.global.lock;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LockService {
+
+
+    private final LockRedisRepository lockRedisRepository;
+
+
+    // 기본 락 타임아웃: 1초
+    private static final Duration DEFAULT_LOCK_TIMEOUT = Duration.ofSeconds(1);
+    // 락 획득 재시도 간격: 5ms
+    private static final long RETRY_INTERVAL_MS = 5;
+    // 최대 재시도 시간: 30초
+    private static final Duration MAX_RETRY_DURATION = Duration.ofSeconds(30);
+
+    /**
+     * 락을 획득하고 작업을 실행
+     *
+     * @param key  락 키 (예: "stock:1")
+     * @param task 실행할 작업
+     * @param <T>  반환 타입
+     * @return 작업 실행 결과
+     */
+    public <T> T executeWithLock(String key, Supplier<T> task) {
+        return executeWithLock(key, task, DEFAULT_LOCK_TIMEOUT);
+    }
+
+    /**
+     * 락을 획득하고 작업을 실행 (타임아웃 지정)
+     *
+     * @param key         락 키
+     * @param task        실행할 작업
+     * @param lockTimeout 락 유지 시간
+     * @param <T>         반환 타입
+     * @return 작업 실행 결과
+     */
+    public <T> T executeWithLock(String key, Supplier<T> task, Duration lockTimeout) {
+        String lockValue = generateLockValue();
+
+        if (!acquireLock(key, lockValue, lockTimeout)) {
+            throw new LockAcquisitionException("Failed to acquire lock for key: " + key);
+        }
+
+        try {
+            return task.get();
+        } finally {
+            releaseLock(key, lockValue);
+        }
+    }
+
+    /**
+     * 락 획득 시도 (재시도 로직 포함)
+     */
+    private boolean acquireLock(String key, String value, Duration lockTimeout) {
+        long startTime = System.currentTimeMillis();
+        long maxRetryTime = MAX_RETRY_DURATION.toMillis();
+
+        while (System.currentTimeMillis() - startTime < maxRetryTime) {
+            Boolean acquired = lockRedisRepository.tryLock(key, value, lockTimeout);
+            if (Boolean.TRUE.equals(acquired)) {
+                return true;
+            }
+
+            try {
+                Thread.sleep(RETRY_INTERVAL_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * 락 해제
+     */
+    private void releaseLock(String key, String value) {
+        try {
+            lockRedisRepository.unlock(key, value);
+        } catch (Exception e) {
+            log.error("Error releasing lock for key: {}", key, e);
+        }
+    }
+        /**
+         * 락 소유자 식별값 생성
+         */
+        private String generateLockValue() {
+            return UUID.randomUUID().toString();
+        }
+    }

--- a/src/test/java/com/example/hotdeal/domain/stock/StockConcurrencyFailTest.java
+++ b/src/test/java/com/example/hotdeal/domain/stock/StockConcurrencyFailTest.java
@@ -1,0 +1,57 @@
+package com.example.hotdeal.domain.stock;
+
+import com.example.hotdeal.domain.stock.application.StockService;
+import com.example.hotdeal.domain.stock.domain.Stock;
+import com.example.hotdeal.domain.stock.infra.StockRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(StockService.class)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+class StockConcurrencyFailTest {
+
+    @Autowired StockRepository repo;
+    @Autowired StockService service;
+    Long stockId;
+
+    @BeforeEach
+    void setUp() {
+        stockId = repo.save(new Stock(1_000)).getId(); // 재고 1000개
+    }
+
+    @Test
+    void should_fail_when_1000_threads_decrease() throws InterruptedException {
+
+        int threadCnt = 1_000;
+        ExecutorService pool = Executors.newFixedThreadPool(128);
+        CountDownLatch latch = new CountDownLatch(threadCnt);
+
+        for (int i = 0; i < threadCnt; i++) {
+            pool.submit(() -> {
+                try {
+                    service.decrease(stockId, 1);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        pool.shutdown();
+
+        int remain = repo.findById(stockId).orElseThrow().getQuantity();
+        System.out.println("남은 재고 = " + remain);
+        assertThat(remain).isZero(); //실패
+    }
+}

--- a/src/test/java/com/example/hotdeal/domain/stock/StockConcurrencySuccessTest.java
+++ b/src/test/java/com/example/hotdeal/domain/stock/StockConcurrencySuccessTest.java
@@ -1,0 +1,85 @@
+package com.example.hotdeal.domain.stock;
+
+
+import com.example.hotdeal.domain.stock.application.StockService;
+import com.example.hotdeal.domain.stock.domain.Stock;
+import com.example.hotdeal.domain.stock.infra.StockRepository;
+import com.example.hotdeal.global.infrastructure.cache.RedisConfig;
+import com.example.hotdeal.global.lock.LockRedisRepository;
+import com.example.hotdeal.global.lock.LockService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+
+import java.util.concurrent.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+
+@SpringBootTest
+@Testcontainers
+@Import({RedisConfig.class, LockRedisRepository.class, LockService.class})
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+class StockConcurrencySuccessTest {
+
+
+    @Container
+    static GenericContainer<?> redis = new GenericContainer<>("redis:7-alpine")
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void properties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", redis::getFirstMappedPort);
+    }
+
+    @Autowired
+    StockRepository repo;
+    @Autowired
+    StockService service;
+    Long stockId;
+
+    @BeforeEach
+    void setUp() {
+        repo.deleteAll();
+        stockId = repo.save(new Stock(1_000)).getId(); // 재고 1000개
+    }
+
+    @Test
+    void should_success_when_1000_threads_decrease_with_lock() throws InterruptedException {
+
+        int threadCnt = 1_000;
+        ExecutorService pool = Executors.newFixedThreadPool(128);
+        CountDownLatch latch = new CountDownLatch(threadCnt);
+
+        for (int i = 0; i < threadCnt; i++) {
+            pool.submit(() -> {
+                try {
+                    service.decreaseWithLock(stockId, 1);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        pool.shutdown();
+
+        int remain = repo.findById(stockId).orElseThrow().getQuantity();
+        System.out.println("남은 재고 = " + remain);
+        assertThat(remain).isZero(); //0개
+    }
+}


### PR DESCRIPTION
## 🚀 PR 요약

재고 관리 도메인과 Redis 기반 분산 락 및 재고 예약 기능을 구현했습니다.

## 💡 변경 사항 상세

- **재고 관리 도메인 기본 구조**
  - `Stock` 엔티티, Repository, Service, Controller 구현
- **Redis Lettuce 기반 분산 락 및 재고 예약 기능**
  - `LockService`, `LockRedisRepository`, `LockAcquisitionException` 추가
  - `RedisConfig` 설정
- **동시성 테스트 코드**
  - 성공/실패 시나리오 테스트 코드 작성 및 백업


## 📝 기타 (선택 사항)

- `dev` 브랜치 Pull 이후 동시성 테스트 일부 실패 (추후 수정 예정)
