### PR TITLE
Feat/오더 생성 V0 버전 구현

### DIFF
--- a/src/main/java/com/example/hotdeal/domain/event/api/EventController.java
+++ b/src/main/java/com/example/hotdeal/domain/event/api/EventController.java
@@ -1,14 +1,15 @@
 package com.example.hotdeal.domain.event.api;
 
 import com.example.hotdeal.domain.event.application.EventService;
-import com.example.hotdeal.domain.event.domain.dto.EventAddProductRequest;
-import com.example.hotdeal.domain.event.domain.dto.EventCrateRequest;
-import com.example.hotdeal.domain.event.domain.dto.EventResponse;
+import com.example.hotdeal.domain.event.domain.dto.*;
+import com.example.hotdeal.domain.event.domain.entity.Event;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/event")
@@ -23,5 +24,13 @@ public class EventController {
     ){
         EventResponse event = eventService.createEvent(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(event);
+    }
+
+    @PostMapping("/search-event")
+    public ResponseEntity<List<EventProductResponse>> getEvents(
+            @RequestBody SearchEventToProductIdRequest request
+    ) {
+        List<EventProductResponse> responses = eventService.getEvent(request.getProductIds());
+        return ResponseEntity.status(HttpStatus.OK).body(responses);
     }
 }

--- a/src/main/java/com/example/hotdeal/domain/event/domain/dto/EventProductResponse.java
+++ b/src/main/java/com/example/hotdeal/domain/event/domain/dto/EventProductResponse.java
@@ -1,0 +1,30 @@
+package com.example.hotdeal.domain.event.domain.dto;
+
+import com.example.hotdeal.domain.event.domain.entity.Event;
+import com.example.hotdeal.domain.event.domain.entity.EventItem;
+import com.example.hotdeal.domain.event.enums.EventType;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+public class EventProductResponse {
+    private Long eventId;
+    private EventType eventType;
+    private BigDecimal eventDiscount;
+    private BigDecimal discountPrice;
+    private int eventDuration;
+    private LocalDateTime startEventTime;
+    private LocalDateTime endEventTime;
+
+    public EventProductResponse(Event event, EventItem eventItem) {
+        this.eventId = event.getEventId();
+        this.eventType = event.getEventType();
+        this.eventDiscount = event.getEventDiscount();
+        this.eventDuration = event.getEventDuration();
+        this.startEventTime = event.getStartEventTime();
+        this.endEventTime = event.getEndEventTime();
+        this.discountPrice = eventItem.getDiscountPrice();
+    }
+}

--- a/src/main/java/com/example/hotdeal/domain/event/domain/dto/SearchEventToProductIdRequest.java
+++ b/src/main/java/com/example/hotdeal/domain/event/domain/dto/SearchEventToProductIdRequest.java
@@ -1,0 +1,21 @@
+package com.example.hotdeal.domain.event.domain.dto;
+
+import jakarta.validation.constraints.AssertTrue;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class SearchEventToProductIdRequest {
+
+    private List<Long> productIds;
+
+    @AssertTrue
+    public boolean isValidList() {
+        return !productIds.isEmpty();
+    }
+
+    public SearchEventToProductIdRequest(List<Long> productIds) {
+        this.productIds = productIds;
+    }
+}

--- a/src/main/java/com/example/hotdeal/domain/event/domain/entity/Event.java
+++ b/src/main/java/com/example/hotdeal/domain/event/domain/entity/Event.java
@@ -20,7 +20,6 @@ public class Event extends BaseEntity {
 
     @Setter
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
-    @Column(name = "product_ids")
     private List<EventItem> products;
 
     @Column(name = "event_type")

--- a/src/main/java/com/example/hotdeal/domain/event/infra/EventRepository.java
+++ b/src/main/java/com/example/hotdeal/domain/event/infra/EventRepository.java
@@ -14,4 +14,11 @@ public interface EventRepository extends JpaRepository<Event,Long> {
     @Query("UPDATE Event e SET e.deleted = true " +
             "WHERE e.endEventTime < :nowTime AND e.deleted = false")
     int softDeleteExpiredEvents(@Param("nowTime") LocalDateTime nowTime);
+
+    @Query("SELECT DISTINCT e FROM Event e " +
+            "JOIN FETCH e.products ei " +
+            "WHERE ei.productId IN :productIds " +
+            "AND e.deleted = false")
+    List<Event> findEventsByProductIds(@Param("productIds") List<Long> productIds);
+
 }

--- a/src/main/java/com/example/hotdeal/domain/order/api/OrderController.java
+++ b/src/main/java/com/example/hotdeal/domain/order/api/OrderController.java
@@ -42,6 +42,15 @@ public class OrderController {
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 
+
+    @PostMapping("/orders/v0")
+    public ResponseEntity<OrderItemResponseDto> addOrderItemsV0(
+            @AuthenticationPrincipal AuthUserDto user,
+            @Valid @RequestBody AddOrderItemRequestDto requestDto
+    ) {
+        OrderItemResponseDto responseDto = orderService.addOrderV0(user.getId(), requestDto);
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+    }
     // 주문 삭제
     @PutMapping("/orders/{orderId}")
     public ResponseEntity<Void> orderCancel(@PathVariable Long orderId){

--- a/src/main/java/com/example/hotdeal/domain/order/application/Service/OrderService.java
+++ b/src/main/java/com/example/hotdeal/domain/order/application/Service/OrderService.java
@@ -156,4 +156,20 @@ public class OrderService {
     }
 
 
+    public OrderItemResponseDto addOrderV0(Long id, AddOrderItemRequestDto requestDto) {
+        //TODO 프로덕트 정보(이름, 가격), 프로덕트 재고(남은 개수), 이벤트 정보(할인율, 할인가격) 호출 필요
+        List<OrderRequestDto> orders = requestDto.getOrderItems();
+
+        // 프로덕트 정보
+        List<OrderItemDto> products = productSearch(orders.stream().map(OrderRequestDto::getProductId).toList()).stream()
+                .map(searchProduct ->
+                    new OrderItemDto(searchProduct.getProductId(), searchProduct.getProductName(), searchProduct.getOriginalPrice())
+                ).toList();
+
+        // 이벤트 정보
+
+
+        // 프로덕트 재고
+        return null;
+    }
 }

--- a/src/main/java/com/example/hotdeal/domain/order/application/dto/OrderResponse.java
+++ b/src/main/java/com/example/hotdeal/domain/order/application/dto/OrderResponse.java
@@ -1,0 +1,21 @@
+package com.example.hotdeal.domain.order.application.dto;
+
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+public class OrderResponse {
+    private final Long orderId;
+    private final Long userId;
+    private final List<OrderItemDto> products;
+    private final BigDecimal totalPrice;
+
+    public OrderResponse(Long orderId, Long userId, List<OrderItemDto> products, BigDecimal totalPrice) {
+        this.orderId = orderId;
+        this.userId = userId;
+        this.products = products;
+        this.totalPrice = totalPrice;
+    }
+}


### PR DESCRIPTION
## 🚀 PR 요약

V2의 가독성 문제로 해결하기위한 예시 코드로서 V0추가

## 💡 변경 사항 상세

레스트 템플릿으로 이벤트 조회하는 기능 추가
그에 필요한 API 추가 작성
재고 기능 완료 시 추가 구현 필요

## 📝 기타 (선택 사항)

응답값을 할당하지 않아 실제 호출은 불가능합니다
