### PR TITLE
feat: 상품 조회 API 및 공통 클라이언트 추가

### DIFF
--- a/src/main/java/com/example/hotdeal/domain/common/client/product/ProductApiClient.java
+++ b/src/main/java/com/example/hotdeal/domain/common/client/product/ProductApiClient.java
@@ -1,0 +1,71 @@
+package com.example.hotdeal.domain.common.client.product;
+
+import com.example.hotdeal.domain.product.product.domain.dto.SearchProductResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductApiClient {
+
+    private final RestTemplate restTemplate;
+    private static final String PRODUCT_API_BASE_URL = "http://localhost:8080/api/products";
+
+    /**
+     * 상품 단건 조회
+     */
+    public SearchProductResponse getProduct(Long productId) {
+        log.debug("상품 단건 조회: productId={}", productId);
+
+        String url = PRODUCT_API_BASE_URL + "/" + productId;
+        return restTemplate.getForObject(url, SearchProductResponse.class);
+    }
+
+    /**
+     * 상품 다건 조회
+     */
+    public List<SearchProductResponse> getProducts(List<Long> productIds) {
+        log.debug("상품 다건 조회: productIds={}", productIds);
+
+        ProductSearchRequest request = new ProductSearchRequest(productIds);
+        URI uri = UriComponentsBuilder
+                .fromUriString(PRODUCT_API_BASE_URL)
+                .path("/search-product")
+                .encode()
+                .build()
+                .toUri();
+
+        ResponseEntity<List<SearchProductResponse>> response = restTemplate.exchange(
+                uri,
+                HttpMethod.POST,
+                new HttpEntity<>(request),
+                new ParameterizedTypeReference<List<SearchProductResponse>>() {}
+        );
+
+        return response.getBody();
+    }
+
+    // 내부 요청 DTO
+    private static class ProductSearchRequest {
+        private final List<Long> productIds;
+
+        public ProductSearchRequest(List<Long> productIds) {
+            this.productIds = productIds;
+        }
+
+        public List<Long> getProductIds() {
+            return productIds;
+        }
+    }
+}

--- a/src/main/java/com/example/hotdeal/domain/product/product/api/ProductController.java
+++ b/src/main/java/com/example/hotdeal/domain/product/product/api/ProductController.java
@@ -34,6 +34,15 @@ public class ProductController {
         return ResponseEntity.ok(products);
     }
 
+    @GetMapping("/{productId}")
+    public ResponseEntity<SearchProductResponse> getProduct(
+            @PathVariable Long productId
+    ) {
+        Product product = productService.findById(productId);
+        SearchProductResponse response = new SearchProductResponse(product);
+        return ResponseEntity.ok(response);
+    }
+
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<CreateProductResponse> createProduct(


### PR DESCRIPTION
- 상품 단건 조회 API 추가 (GET /api/products/{id})
- ProductApiClient 구현 (단건/다건 조회)
- Common 패키지에 API 클라이언트 구성
- 도메인 간 상품 데이터 조회를 위한 공통 인터페이스 제공




- 기존의 사용하던 클래스들은 충돌날까봐 별도로 이동 안했고, 추후에 다같이 리펙토링 할 예정