### PR TITLE
Feat/재고 차감 트랜잭션 Propagation.REQUIRES_NEW로 분리

### DIFF
--- a/src/main/java/com/example/hotdeal/domain/stock/application/StockTransactionService.java
+++ b/src/main/java/com/example/hotdeal/domain/stock/application/StockTransactionService.java
@@ -5,6 +5,7 @@ import com.example.hotdeal.domain.stock.infra.StockRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
@@ -14,7 +15,7 @@ class StockTransactionService {
 
     private final StockRepository repository;
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void decreaseInNewTransaction(Long stockId, int quantity) {
         Stock stock = repository.findById(stockId)
                 .orElseThrow(() -> new IllegalArgumentException("재고를 찾을 수 없습니다. ID = " + stockId));


### PR DESCRIPTION

## 🚀 PR 요약

- 재고 차감 트랜잭션 Propagation.REQUIRES_NEW로 분리

## 💡 변경 사항 상세

- StockTransactionService.decreaseInNewTransaction()에 Propagation.REQUIRES_NEW 적용
- 재고 차감이 부모 트랜잭션(handleOrderCreatedEvent)과 독립적으로 커밋/롤백되도록 변경
- 재고 차감 실패 시 이벤트 처리에서 영향 최소화

