### PR TITLE
refactor: 코드 리팩토링

### DIFF
--- a/src/main/java/com/example/hotdeal/domain/common/client/product/dto/SearchProductResponse.java
+++ b/src/main/java/com/example/hotdeal/domain/common/client/product/dto/SearchProductResponse.java
@@ -2,7 +2,9 @@ package com.example.hotdeal.domain.common.client.product.dto;
 
 import com.example.hotdeal.domain.product.domain.Product;
 import com.example.hotdeal.domain.product.domain.ProductCategory;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 
@@ -10,6 +12,8 @@ import java.math.BigDecimal;
  * 프로덕트 조회 결과
  */
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class SearchProductResponse {
     private Long productId;
     private String productName;
@@ -17,8 +21,6 @@ public class SearchProductResponse {
     private String productDescription;
     private String productImageUri;
     private ProductCategory productCategory;
-
-    public SearchProductResponse() {}
 
     public SearchProductResponse(Product product) {
         this.productId = product.getProductId();

--- a/src/main/java/com/example/hotdeal/domain/event/api/EventController.java
+++ b/src/main/java/com/example/hotdeal/domain/event/api/EventController.java
@@ -5,12 +5,14 @@ import com.example.hotdeal.domain.event.application.EventService;
 import com.example.hotdeal.domain.event.domain.dto.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/event")
 @RequiredArgsConstructor
@@ -22,7 +24,9 @@ public class EventController {
     public ResponseEntity<EventResponse> createEvent(
             @Valid @RequestBody EventCrateRequest request
     ){
+        long startTime = System.currentTimeMillis();
         EventResponse event = eventService.createEvent(request);
+        log.info("8단계 - 컨트롤러 실행: {}ms", System.currentTimeMillis() - startTime);
         return ResponseEntity.status(HttpStatus.CREATED).body(event);
     }
 

--- a/src/main/java/com/example/hotdeal/domain/event/application/EventPublisherAsync.java
+++ b/src/main/java/com/example/hotdeal/domain/event/application/EventPublisherAsync.java
@@ -1,0 +1,25 @@
+package com.example.hotdeal.domain.event.application;
+
+import com.example.hotdeal.domain.event.domain.dto.WSEventProduct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class EventPublisherAsync {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void publishEvent(List<WSEventProduct> wsEventProducts) {
+        wsEventProducts.forEach(eventPublisher::publishEvent);
+    }
+}

--- a/src/main/java/com/example/hotdeal/domain/event/application/EventService.java
+++ b/src/main/java/com/example/hotdeal/domain/event/application/EventService.java
@@ -6,6 +6,7 @@ import com.example.hotdeal.domain.common.client.product.ProductApiClient;
 import com.example.hotdeal.domain.event.domain.dto.*;
 import com.example.hotdeal.domain.event.domain.entity.Event;
 import com.example.hotdeal.domain.event.domain.entity.EventItem;
+import com.example.hotdeal.domain.event.infra.EventItemInsertRepository;
 import com.example.hotdeal.domain.event.infra.EventRepository;
 import com.example.hotdeal.domain.common.client.product.dto.SearchProductResponse;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.*;
+import com.example.hotdeal.domain.event.infra.EventItemRepository;
 
 
 @Slf4j
@@ -25,10 +27,10 @@ import java.util.*;
 public class EventService {
 
     private final EventRepository eventRepository;
-    private final ApplicationEventPublisher eventPublisher;
-    private final HotDealApiClient apiClient;
+    private final EventItemRepository eventItemRepository;
+    private final EventItemInsertRepository eventItemInsertRepository;
+    private final EventPublisherAsync eventPublisher;
     private final ProductApiClient productApiClient;
-
     /**
      * 이벤트 생성
      *
@@ -36,12 +38,41 @@ public class EventService {
      */
     @Transactional
     public EventResponse createEvent(EventCrateRequest request) {
+        long totalStartTime = System.currentTimeMillis();
+        
+        // 1. Event 저장
+        long step1Start = System.currentTimeMillis();
         Event event = eventRepository.save(request.toEvent());
+        long step1End = System.currentTimeMillis();
+        log.info("1단계 - Event 저장 완료: {}ms", (step1End - step1Start));
+        
+        // 2. ProductApiClient 호출 (외부 API)
+        long step2Start = System.currentTimeMillis();
         List<SearchProductResponse> searchProductResponses = productApiClient.getProducts(request.getProductIds());
-        List<EventItem> eventItems = searchProductResponses.stream().map(response -> new EventItem(response, event.getEventDiscount(), event))
+        long step2End = System.currentTimeMillis();
+        log.info("2단계 - ProductApiClient 호출 완료: {}ms, 조회된 상품 수: {}", (step2End - step2Start), searchProductResponses.size());
+        
+        // 3. EventItem 객체 생성
+        long step3Start = System.currentTimeMillis();
+        List<EventItem> eventItems = searchProductResponses.stream().map(response -> new EventItem(response, event.getEventDiscount(), event.getEventId()))
                 .toList();
+        long step3End = System.currentTimeMillis();
+        log.info("3단계 - EventItem 객체 생성 완료: {}ms", (step3End - step3Start));
+        
+        // 4. EventItem 벌크 insert
+        long step4Start = System.currentTimeMillis();
+        eventItemInsertRepository.insertEventItem(eventItems, event.getEventId());
+        long step4End = System.currentTimeMillis();
+        log.info("4단계 - EventItem 벌크 insert 완료: {}ms", (step4End - step4Start));
+        
+        // 5. Event에 EventItem 리스트 설정 (조회용)
+        long step5Start = System.currentTimeMillis();
         event.setProducts(eventItems);
-
+        long step5End = System.currentTimeMillis();
+        log.info("5단계 - Event에 EventItem 리스트 설정 완료: {}ms", (step5End - step5Start));
+        
+        // 6. WSEventProduct 객체 생성
+        long step6Start = System.currentTimeMillis();
         List<WSEventProduct> wsEventProducts = eventItems.stream()
                 .map(eventItem ->
                         new WSEventProduct(
@@ -55,13 +86,17 @@ public class EventService {
                         )
                 )
                 .toList();
+        long step6End = System.currentTimeMillis();
+        log.info("6단계 - WSEventProduct 객체 생성 완료: {}ms", (step6End - step6Start));
 
+        long step7Start = System.currentTimeMillis();
         log.info("이벤트 발행 시작 - 총 {}개 이벤트", wsEventProducts.size());
-        wsEventProducts.forEach(wsEvent -> {
-            log.info("이벤트 발행: {}", wsEvent.product_id());
-            eventPublisher.publishEvent(wsEvent);
-        });
-        log.info("이벤트 발행 완료");
+        eventPublisher.publishEvent(wsEventProducts);
+        long step7End = System.currentTimeMillis();
+        log.info("7단계 - 이벤트 발행 완료: {}ms", (step7End - step7Start));
+        
+        long totalEndTime = System.currentTimeMillis();
+        log.info("=== createEvent 총 실행시간: {}ms ===", (totalEndTime - totalStartTime));
 
         return new EventResponse(event);
     }
@@ -75,13 +110,19 @@ public class EventService {
     }
 
     public List<EventProductResponse> getEvent(List<Long> productIds) {
-        List<Event> events = eventRepository.findEventsByProductIds(productIds);
+        // 연관관계 제거로 인해 Event와 EventItem을 별도로 조회
+        List<Event> events = eventRepository.findActiveEvents();
+        List<EventItem> eventItems = eventItemRepository.findByProductIds(productIds);
 
         Map<Long, EventProductResponse> bestDealEventsMap = new HashMap<>();
 
         for (Event event : events) {
+            // 해당 이벤트의 EventItem들만 필터링
+            List<EventItem> eventEventItems = eventItems.stream()
+                    .filter(item -> item.getEventId().equals(event.getEventId()))
+                    .toList();
 
-            for (EventItem eventItem : event.getProducts()) {
+            for (EventItem eventItem : eventEventItems) {
                 Long currentProductId = eventItem.getProductId();
 
                 if (productIds.contains(currentProductId)) {

--- a/src/main/java/com/example/hotdeal/domain/event/domain/dto/EventCrateRequest.java
+++ b/src/main/java/com/example/hotdeal/domain/event/domain/dto/EventCrateRequest.java
@@ -4,6 +4,7 @@ import com.example.hotdeal.domain.event.domain.entity.Event;
 import com.example.hotdeal.domain.event.enums.EventType;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.math.BigDecimal;
@@ -14,6 +15,7 @@ import java.util.List;
  * 이벤트 생성 DTO
  */
 @Getter
+@AllArgsConstructor
 public class EventCrateRequest {
 
     @NotNull

--- a/src/main/java/com/example/hotdeal/domain/event/domain/dto/EventResponse.java
+++ b/src/main/java/com/example/hotdeal/domain/event/domain/dto/EventResponse.java
@@ -18,7 +18,10 @@ public class EventResponse {
 
     public EventResponse(Event event) {
         this.eventId = event.getEventId();
-        this.productId = event.getProducts().stream().map(EventItem::getProductId).collect(Collectors.toList());
+        // 연관관계 제거로 인해 products가 null일 수 있으므로 안전하게 처리
+        this.productId = event.getProducts() != null ? 
+            event.getProducts().stream().map(EventItem::getProductId).collect(Collectors.toList()) : 
+            List.of();
         this.startEventTime = event.getStartEventTime();
         this.endEventTime = event.getStartEventTime().plusDays(event.getEventDuration());
     }

--- a/src/main/java/com/example/hotdeal/domain/event/domain/entity/Event.java
+++ b/src/main/java/com/example/hotdeal/domain/event/domain/entity/Event.java
@@ -18,10 +18,6 @@ public class Event extends BaseEntity {
     @Column(name = "event_id")
     private Long eventId;
 
-    @Setter
-    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
-    private List<EventItem> products;
-
     @Column(name = "event_type")
     private EventType eventType;
 
@@ -36,6 +32,10 @@ public class Event extends BaseEntity {
 
     @Column(name = "end_event_time")
     private LocalDateTime endEventTime;
+
+    @Transient
+    @Setter
+    private List<EventItem> products;
 
     public Event() {}
 

--- a/src/main/java/com/example/hotdeal/domain/event/domain/entity/EventItem.java
+++ b/src/main/java/com/example/hotdeal/domain/event/domain/entity/EventItem.java
@@ -3,36 +3,41 @@ package com.example.hotdeal.domain.event.domain.entity;
 import com.example.hotdeal.domain.common.client.product.dto.SearchProductResponse;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.math.BigDecimal;
 
 @Entity
 @Getter
-@Table(name = "event_items") // 자식 테이블
+@Setter
+@Table(name = "event_items")
 public class EventItem {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "item_id")
     private Long itemId;
+    
     @Column(name = "product_id")
     private Long productId;
+    
     @Column(name = "discount_price")
     private BigDecimal discountPrice;
+    
     @Column(name = "original_price")
     private BigDecimal originalPrice;
+    
     @Column(name = "product_name")
     private String productName;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "event_id")
-    private Event event;
+    @Column(name = "event_id")
+    private Long eventId;
 
-    public EventItem(SearchProductResponse response, BigDecimal discount, Event event) {
+    public EventItem(SearchProductResponse response, BigDecimal discount, Long eventId) {
         this.productId = response.getProductId();
         this.productName = response.getProductName();
         this.originalPrice = response.getOriginalPrice();
         BigDecimal finalRate = BigDecimal.ONE.subtract(discount.divide(new BigDecimal("100")));
         this.discountPrice = response.getOriginalPrice().multiply(finalRate);
-        this.event = event;
+        this.eventId = eventId;  // Event 엔티티 대신 ID만 저장
     }
 
     public EventItem() {

--- a/src/main/java/com/example/hotdeal/domain/event/infra/EventItemInsertRepository.java
+++ b/src/main/java/com/example/hotdeal/domain/event/infra/EventItemInsertRepository.java
@@ -1,0 +1,37 @@
+package com.example.hotdeal.domain.event.infra;
+
+import com.example.hotdeal.domain.event.domain.entity.Event;
+import com.example.hotdeal.domain.event.domain.entity.EventItem;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class EventItemInsertRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public void insertEventItem(List<EventItem> eventItems, Long eventId) {
+        String sql = "INSERT INTO event_items (product_id, discount_price, original_price, product_name, event_id) VALUES (?, ?, ?, ?, ?)";
+        
+        log.info("EventItem JDBC 벌크 insert 시작 - size: {}", eventItems.size());
+        long startTime = System.currentTimeMillis();
+        
+        jdbcTemplate.batchUpdate(sql, eventItems, 1000, (ps, item) -> {
+            ps.setLong(1, item.getProductId());
+            ps.setBigDecimal(2, item.getDiscountPrice());
+            ps.setBigDecimal(3, item.getOriginalPrice());
+            ps.setString(4, item.getProductName());
+            ps.setLong(5, eventId);  // 직접 eventId 사용
+        });
+        
+        long endTime = System.currentTimeMillis();
+        log.info("EventItem JDBC 벌크 insert 완료 - 총 {}건, 소요시간: {}ms",
+                 eventItems.size(), (endTime - startTime));
+    }
+}

--- a/src/main/java/com/example/hotdeal/domain/event/infra/EventRepository.java
+++ b/src/main/java/com/example/hotdeal/domain/event/infra/EventRepository.java
@@ -15,10 +15,9 @@ public interface EventRepository extends JpaRepository<Event,Long> {
             "WHERE e.endEventTime < :nowTime AND e.deleted = false")
     int softDeleteExpiredEvents(@Param("nowTime") LocalDateTime nowTime);
 
-    @Query("SELECT DISTINCT e FROM Event e " +
-            "JOIN FETCH e.products ei " +
-            "WHERE ei.productId IN :productIds " +
-            "AND e.deleted = false")
-    List<Event> findEventsByProductIds(@Param("productIds") List<Long> productIds);
+    // 연관관계 제거로 인해 단순 Event 조회로 변경
+    @Query("SELECT e FROM Event e " +
+            "WHERE e.deleted = false")
+    List<Event> findActiveEvents();
 
 }

--- a/src/main/java/com/example/hotdeal/domain/notification/application/NotificationService.java
+++ b/src/main/java/com/example/hotdeal/domain/notification/application/NotificationService.java
@@ -3,12 +3,20 @@ package com.example.hotdeal.domain.notification.application;
 import com.example.hotdeal.domain.notification.domain.ListenProductEvent;
 import com.example.hotdeal.domain.notification.domain.Notification;
 import com.example.hotdeal.domain.notification.infra.NotificationRepository;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContext;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
@@ -17,14 +25,23 @@ public class NotificationService {
 
     private final NotificationRepository notificationRepository;
     private final SimpMessagingTemplate messagingTemplate;
+    private final List<Notification> buffer = new ArrayList<>();
+    private final Object lock = new Object();
+    private long lastInsertTime = System.currentTimeMillis();
+    private final ApplicationContext context;
 
+    @PostConstruct
+    public void init() {
+        insertTimer();
+    }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void notifyProductEventMessage(ListenProductEvent listenProductEvent) {
         log.info("NotificationService.notifyProductEventMessage 시작");
 
         Notification notification = listenProductEvent.toNotification();
-        notificationRepository.save(notification);
+        addNotification(notification);            // 벌크 insert
+        //notificationRepository.save(notification); // 기존 insert
         String notificationMessages = notification.getNotification_message();
 
         log.info("웹소켓 메시지 전송 시작: {}", notificationMessages);
@@ -41,4 +58,37 @@ public class NotificationService {
         }
     }
 
+    @Async
+    public void insertBatch() {
+        List<Notification> notifications;
+        synchronized (lock) {
+            notifications = new ArrayList<>(buffer);
+            buffer.clear();
+        }
+        log.info("알림 insert 실행");
+        notificationRepository.insertNotifications(notifications);
+    }
+
+    public void addNotification(Notification notification) {
+        log.info("알림 버퍼에 추가");
+        synchronized (lock) {
+            buffer.add(notification);
+            if(buffer.size() >= 1000) {
+                log.debug("알림 개수 1000개 이상 생성");
+                ((NotificationService) context.getBean(NotificationService.class)).insertBatch();
+            }
+        }
+        lastInsertTime = System.currentTimeMillis();
+    }
+
+    private void insertTimer() {
+        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> {
+            synchronized (lock) {
+                if (!buffer.isEmpty() && System.currentTimeMillis() - lastInsertTime >= 5000) {
+                    log.debug("알림 스케줄러 실행");
+                    ((NotificationService) context.getBean(NotificationService.class)).insertBatch();
+                }
+            }
+        }, 1, 1, TimeUnit.SECONDS);
+    }
 }

--- a/src/main/java/com/example/hotdeal/domain/notification/infra/NotificationRepository.java
+++ b/src/main/java/com/example/hotdeal/domain/notification/infra/NotificationRepository.java
@@ -3,5 +3,5 @@ package com.example.hotdeal.domain.notification.infra;
 import com.example.hotdeal.domain.notification.domain.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface NotificationRepository extends JpaRepository<Notification, Integer> {
+public interface NotificationRepository extends JpaRepository<Notification, Integer>, NotifyInsertRepository {
 }

--- a/src/main/java/com/example/hotdeal/domain/notification/infra/NotifyInsertRepository.java
+++ b/src/main/java/com/example/hotdeal/domain/notification/infra/NotifyInsertRepository.java
@@ -1,0 +1,9 @@
+package com.example.hotdeal.domain.notification.infra;
+
+import com.example.hotdeal.domain.notification.domain.Notification;
+
+import java.util.List;
+
+public interface NotifyInsertRepository {
+    void insertNotifications(List<Notification> notification);
+}

--- a/src/main/java/com/example/hotdeal/domain/notification/infra/NotifyInsertRepositoryImpl.java
+++ b/src/main/java/com/example/hotdeal/domain/notification/infra/NotifyInsertRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.example.hotdeal.domain.notification.infra;
+
+import com.example.hotdeal.domain.notification.domain.Notification;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.StatelessSession;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class NotifyInsertRepositoryImpl implements NotifyInsertRepository {
+
+    private final SessionFactory sessionFactory;
+
+    public void insertNotifications(List<Notification> notifications) {
+        StatelessSession session = sessionFactory.openStatelessSession();
+        session.beginTransaction();
+
+        try {
+            log.info("저장 시작 size = {}", notifications.size());
+            for(Notification note : notifications){
+                session.insert(note);
+            }
+            session.getTransaction().commit();
+            log.info("저장 끝");
+        } catch (Exception e) {
+            session.getTransaction().rollback();
+            throw e;
+        } finally {
+            session.close();
+        }
+    }
+}

--- a/src/main/java/com/example/hotdeal/domain/user/auth/security/SecurityConfig.java
+++ b/src/main/java/com/example/hotdeal/domain/user/auth/security/SecurityConfig.java
@@ -44,7 +44,10 @@ public class SecurityConfig {
                     .requestMatchers(
                         "/api/auth/signup",
                         "/api/auth/login",
-                        "/api/auth/reissue"
+                        "/api/auth/reissue",
+                        "/ws/**",
+                        "/topic/**",
+                        "/app/**"
                     )
                     .permitAll()
                     .anyRequest()

--- a/src/test/java/com/example/hotdeal/EventTest.java
+++ b/src/test/java/com/example/hotdeal/EventTest.java
@@ -1,0 +1,104 @@
+package com.example.hotdeal;
+import com.example.hotdeal.domain.common.client.product.ProductApiClient;
+import com.example.hotdeal.domain.common.client.product.dto.SearchProductResponse;
+import com.example.hotdeal.domain.event.domain.dto.EventCrateRequest;
+import com.example.hotdeal.domain.event.enums.EventType;
+import com.example.hotdeal.domain.notification.infra.NotificationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.example.hotdeal.domain.product.domain.ProductCategory;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class EventTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @SuppressWarnings("removal")
+    @MockBean
+    private ProductApiClient productApiClient;
+
+    @BeforeEach
+    void setUp() {
+        List<SearchProductResponse> mockProducts = new ArrayList<>();
+        ProductCategory[] categories = ProductCategory.values();
+        
+        // 미리 계산된 값들을 준비
+        BigDecimal basePrice = BigDecimal.valueOf(10000);
+        
+        for (long i = 1; i <= 10000; i++) {
+            // BigDecimal 계산을 최소화
+            BigDecimal price = basePrice.add(BigDecimal.valueOf(i));
+            
+            mockProducts.add(new SearchProductResponse(
+                i, // productId
+                "테스트상품" + i, // productName
+                price, // originalPrice (미리 계산)
+                "설명" + i, // productDescription
+                "https://example.com/image" + i + ".jpg", // productImageUri
+                categories[(int)(i % categories.length)] // productCategory
+            ));
+        }
+        when(productApiClient.getProducts(anyList()))
+                .thenReturn(mockProducts);
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void 이벤트_생성시_알림_10000개_벌크인서트_테스트() throws Exception {
+        // given: 10,000개 상품 ID 등 이벤트 생성 요청 데이터 준비
+        List<Long> productIds = new ArrayList<>();
+        for (long i = 1; i <= 10000; i++) {
+            productIds.add(i);
+        }
+        EventCrateRequest request = new EventCrateRequest(
+                EventType.HOT_DEAL, BigDecimal.TEN, 7, LocalDateTime.now(), productIds// 필요한 필드 채우기
+        );
+
+        // when: 이벤트 생성 API 호출
+        mockMvc.perform(post("/api/event/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated());
+
+        // then: 알림이 10,000개 생성됐는지 확인 (비동기 벌크 인서트 대기)
+        int retry = 0;
+        long count = 0;
+        do {
+            Thread.sleep(1000); // 1초 대기
+            count = notificationRepository.count();
+            retry++;
+        } while (count < 10000 && retry < 10);
+
+        assertEquals(10000, count, "알림이 10,000개 생성되어야 합니다.");
+    }
+}
+

--- a/src/test/java/com/example/hotdeal/ProductDataInsertTest.java
+++ b/src/test/java/com/example/hotdeal/ProductDataInsertTest.java
@@ -1,22 +1,33 @@
 package com.example.hotdeal;
 
+import com.example.hotdeal.domain.event.domain.dto.EventCrateRequest;
+import com.example.hotdeal.domain.event.enums.EventType;
+import com.example.hotdeal.domain.notification.infra.NotificationRepository;
 import com.example.hotdeal.domain.product.domain.Product;
 import com.example.hotdeal.domain.product.domain.ProductCategory;
 import com.example.hotdeal.domain.product.infra.ProductRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.mock.http.server.reactive.MockServerHttpRequest.post;
+
 @SpringBootTest
 @ActiveProfiles("test")
-@WithMockUser(username = "testuser", roles = {"USER"})
+@TestPropertySource(properties = {
+    "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration"
+})
 public class ProductDataInsertTest {
 
     @Autowired
@@ -38,4 +49,6 @@ public class ProductDataInsertTest {
         }
         productRepository.saveAll(products);
     }
+
+
 } 

--- a/websocket-test.html
+++ b/websocket-test.html
@@ -42,34 +42,134 @@
     <title>WebSocket Test</title>
     <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        .status { padding: 10px; margin: 10px 0; border-radius: 5px; }
+        .success { background-color: #d4edda; color: #155724; }
+        .error { background-color: #f8d7da; color: #721c24; }
+        .info { background-color: #d1ecf1; color: #0c5460; }
+        #messages { max-height: 400px; overflow-y: auto; border: 1px solid #ccc; padding: 10px; }
+    </style>
 </head>
 <body>
     <h1>WebSocket 알림 테스트</h1>
+    
+    <div class="status info">
+        <strong>연결 상태:</strong> <span id="connectionStatus">연결 시도 중...</span>
+    </div>
+    
+    <div>
+        <button onclick="testConnection()">연결 테스트</button>
+        <button onclick="clearMessages()">메시지 지우기</button>
+    </div>
+    
     <div id="messages"></div>
     
     <script>
-        const socket = new SockJS('http://localhost:8080/ws');
-        const stompClient = Stomp.over(socket);
+        let stompClient = null;
+        let socket = null;
         
-        stompClient.connect({}, function(frame) {
-            console.log('Connected: ' + frame);
-            document.getElementById('messages').innerHTML += '<p>✅ 웹소켓 연결 성공</p>';
+        function addMessage(message, type = 'info') {
+            const messagesDiv = document.getElementById('messages');
+            const timestamp = new Date().toLocaleTimeString();
+            const messageDiv = document.createElement('div');
+            messageDiv.className = `status ${type}`;
+            messageDiv.innerHTML = `<strong>[${timestamp}]</strong> ${message}`;
+            messagesDiv.appendChild(messageDiv);
+            messagesDiv.scrollTop = messagesDiv.scrollHeight;
+        }
+        
+        function updateConnectionStatus(status, type = 'info') {
+            document.getElementById('connectionStatus').textContent = status;
+            document.getElementById('connectionStatus').className = type;
+        }
+        
+        function connect() {
+            addMessage('웹소켓 연결 시도 중...', 'info');
             
-            stompClient.subscribe('/topic/notification', function(message) {
-                console.log('알림 받음:', message.body);
-                document.getElementById('messages').innerHTML += '<p>🔔 알림: ' + message.body + '</p>';
-            });
-        }, function(error) {
-            console.log('STOMP error: ' + error);
-            document.getElementById('messages').innerHTML += '<p>❌ 연결 실패: ' + error + '</p>';
+            try {
+                // SockJS를 통한 연결
+                socket = new SockJS('http://localhost:8080/ws');
+                stompClient = Stomp.over(socket);
+                
+                // 디버그 모드 활성화
+                stompClient.debug = function(str) {
+                    console.log('STOMP Debug:', str);
+                    addMessage('STOMP Debug: ' + str, 'info');
+                };
+                
+                stompClient.connect({}, 
+                    function(frame) {
+                        console.log('Connected: ' + frame);
+                        addMessage('✅ 웹소켓 연결 성공: ' + frame, 'success');
+                        updateConnectionStatus('연결됨', 'success');
+                        
+                        // 알림 구독
+                        stompClient.subscribe('/topic/notification', function(message) {
+                            console.log('알림 받음:', message.body);
+                            addMessage('🔔 알림: ' + message.body, 'success');
+                        });
+                        
+                        // 이벤트 구독
+                        stompClient.subscribe('/topic/events', function(message) {
+                            console.log('이벤트 받음:', message.body);
+                            addMessage('📡 이벤트: ' + message.body, 'success');
+                        });
+                        
+                    }, 
+                    function(error) {
+                        console.log('STOMP error: ' + error);
+                        addMessage('❌ 연결 실패: ' + error, 'error');
+                        updateConnectionStatus('연결 실패', 'error');
+                    }
+                );
+                
+            } catch (error) {
+                console.error('연결 오류:', error);
+                addMessage('❌ 연결 오류: ' + error.message, 'error');
+                updateConnectionStatus('연결 오류', 'error');
+            }
+        }
+        
+        function testConnection() {
+            addMessage('연결 테스트 시작...', 'info');
+            
+            // 기존 연결이 있으면 해제
+            if (stompClient && stompClient.connected) {
+                stompClient.disconnect();
+                addMessage('기존 연결 해제', 'info');
+            }
+            
+            // 새로 연결
+            setTimeout(connect, 1000);
+        }
+        
+        function clearMessages() {
+            document.getElementById('messages').innerHTML = '';
+        }
+        
+        // 페이지 로드 시 자동 연결
+        window.onload = function() {
+            addMessage('페이지 로드됨, 웹소켓 연결 시도...', 'info');
+            connect();
+        };
+        
+        // 페이지 종료 시 연결 해제
+        window.addEventListener('beforeunload', function() {
+            if (stompClient && stompClient.connected) {
+                stompClient.disconnect();
+                addMessage('페이지 종료로 인한 연결 해제', 'info');
+            }
         });
         
         // 연결 상태 모니터링
-        window.addEventListener('beforeunload', function() {
-            if (stompClient.connected) {
-                stompClient.disconnect();
+        setInterval(function() {
+            if (stompClient && stompClient.connected) {
+                updateConnectionStatus('연결됨', 'success');
+            } else {
+                updateConnectionStatus('연결 끊김', 'error');
             }
-        });
+        }, 5000);
     </script>
 </body>
 </html> 


### PR DESCRIPTION
## 🚀 PR 요약

event 도메인 성능 튜닝

## 💡 변경 사항 상세

createEvent 성능 튜닝
1. 연관 관계 매핑 제거
- 대용량으로 이벤트가 생성될 경우 연관관계 매핑 테이블 insert로 인해 성능 저하 발생으로 연관관계 제거
2. EventItem 테이블 jdbc 벌크 insert 구현으로 성능 개선
3. EventService에서 이벤트 발행부분 비동기로 진행 단, 트랜잭션을 공유해야하기 때문에 createEvent의 트랜잭션이 정상적으로 완료된 시점에 실행되어 성능에 지장이 없도록 작성
4. notification StatelessSesstion을 통한 벌크 insert 진행
5. 시큐리티에 웹소켓 허용

